### PR TITLE
Fixed ExecutorsCreate example

### DIFF
--- a/src/main/scala/org/learningconcurrency/ch3/Executors.scala
+++ b/src/main/scala/org/learningconcurrency/ch3/Executors.scala
@@ -12,6 +12,8 @@ object ExecutorsCreate extends App {
   executor.execute(new Runnable {
     def run() = log("This task is run asynchronously.")
   })
+
+  Thread.sleep(500)
 }
 
 


### PR DESCRIPTION
  - added missed Thread.sleep(500) to ExecutorsCreate example to wait until log message is being printed in console.