### PR TITLE
Fix index initialization and loop termination condition of `LockFreePool`'s `remove` method

### DIFF
--- a/src/main/scala/org/learningconcurrency/ch3/LockFreePool.scala
+++ b/src/main/scala/org/learningconcurrency/ch3/LockFreePool.scala
@@ -33,9 +33,9 @@ object LockFreePool {
     def remove(): Option[T] = {
       val start = (Thread.currentThread.getId % buckets.length).toInt
       @tailrec def scan(witness: Long): Option[T] = {
-        var i = (start + 1) % buckets.length
+        var i = start
         var sum = 0L
-        while (i != start) {
+        do {
           val bucket = buckets(i)
 
           @tailrec def retry(): Option[T] = {
@@ -55,7 +55,7 @@ object LockFreePool {
           }
 
           i = (i + 1) % buckets.length
-        }
+        } while (i != start)
         if (sum == witness) None
         else scan(sum)
       }


### PR DESCRIPTION
Hi, I'm reading your book these days (thanks for your interesting book) , and I ran into the error below while I was running `LockFreePool` example.
![image](https://github.com/concurrent-programming-in-scala/learning-examples/assets/18438185/25d2e37f-5dbc-42bf-ac59-9e285838e527)

I think the reason is because the existing implementation incorrectly terminates the loop without checking the bucket at the starting index (`start`). So, I fixed it by modifying the loop to `do-while` from `while` and initializing `i` with `start` instead of `(start + 1) % buckets.length`. It will ensure that the bucket at the starting index is also considered during the scan.

